### PR TITLE
Fix the bug that occurs the chat is loaded while offline

### DIFF
--- a/components/screens/Chat.js
+++ b/components/screens/Chat.js
@@ -79,7 +79,10 @@ export default function Chat({ route, navigation }) {
 			try {
 				const conversation = await AsyncStorage.getItem(chatId);
 				const messages = JSON.parse(conversation) || [];
-				setChats(messages);
+				setChats(messages.map(message => ({
+					...message,
+					time: new Date(message.time)
+				})));
 			} catch (e) {
 				console.log("Get chats", e);
 			}


### PR DESCRIPTION
The chat history is stored as a JSON, which converts `Date` objects into strings. However, the current implementation does not restore the string into `Date` when parsing the stored JSON, which caused a display error.